### PR TITLE
Include valid?/3 in the Conformable protocol

### DIFF
--- a/lib/norm.ex
+++ b/lib/norm.ex
@@ -76,10 +76,7 @@ defmodule Norm do
       false
   """
   def valid?(input, spec) do
-    case Conformer.conform(spec, input) do
-      {:ok, _} -> true
-      {:error, _} -> false
-    end
+    Conformer.valid?(spec, input)
   end
 
   @doc ~S"""

--- a/lib/norm/conformer.ex
+++ b/lib/norm/conformer.ex
@@ -7,6 +7,10 @@ defmodule Norm.Conformer do
     Norm.Conformer.Conformable.conform(spec, input, [])
   end
 
+  def valid?(spec, input) do
+    Norm.Conformer.Conformable.valid?(spec, input, [])
+  end
+
   def group_results(results) do
     results
     |> Enum.reduce(%{ok: [], error: []}, fn {result, s}, acc ->
@@ -48,10 +52,12 @@ defmodule Norm.Conformer do
   defprotocol Conformable do
     @moduledoc false
     # Defines a conformable type. Must take the type, current path, and input and
-    # return an success tuple with the conformed data or a list of errors.
+    # return a success tuple with the conformed data or a list of errors.
 
     # @fallback_to_any true
     def conform(spec, path, input)
+
+    def valid?(spec, path, input)
   end
 end
 
@@ -70,11 +76,15 @@ defimpl Norm.Conformer.Conformable, for: Atom do
         {:error, [Conformer.error(path, input, "is not an atom.")]}
 
       atom != input ->
-        {:error, [Conformer.error(path, input, "== :#{atom}")]}
+        {:error, [Conformer.error(path, input, "== #{inspect(atom)}")]}
 
       true ->
         {:ok, atom}
     end
+  end
+
+  def valid?(atom, input, path) do
+    conform(atom, input, path) |> elem(0) == :ok
   end
 end
 
@@ -103,5 +113,9 @@ defimpl Norm.Conformer.Conformable, for: Tuple do
     else
       {:ok, List.to_tuple(results.ok)}
     end
+  end
+
+  def valid?(spec, input, path) do
+    conform(spec, input, path) |> elem(0) == :ok
   end
 end

--- a/lib/norm/core/all_of.ex
+++ b/lib/norm/core/all_of.ex
@@ -23,6 +23,11 @@ defmodule Norm.Core.AllOf do
         {:ok, Enum.at(result.ok, 0)}
       end
     end
+
+    def valid?(%{specs: specs}, input, path) do
+      specs
+      |> Stream.map(fn spec -> Conformable.valid?(spec, input, path) end)
+      |> Enum.all?(& &1)
+    end
   end
 end
-

--- a/lib/norm/core/alt.ex
+++ b/lib/norm/core/alt.ex
@@ -27,6 +27,12 @@ defmodule Norm.Core.Alt do
         {:error, List.flatten(result.error)}
       end
     end
+
+    def valid?(%{specs: specs}, input, path) do
+      specs
+      |> Stream.map(fn {name, spec} -> Conformable.valid?(spec, input, path ++ [name]) end)
+      |> Enum.any?(& &1)
+    end
   end
 
   if Code.ensure_loaded?(StreamData) do

--- a/lib/norm/core/any_of.ex
+++ b/lib/norm/core/any_of.ex
@@ -24,6 +24,12 @@ defmodule Norm.Core.AnyOf do
         {:error, List.flatten(result.error)}
       end
     end
+
+    def valid?(%{specs: specs}, input, path) do
+      specs
+      |> Stream.map(fn spec -> Conformable.valid?(spec, input, path) end)
+      |> Enum.all?(& &1)
+    end
   end
 
   if Code.ensure_loaded?(StreamData) do

--- a/lib/norm/core/collection.ex
+++ b/lib/norm/core/collection.ex
@@ -47,6 +47,18 @@ defmodule Norm.Core.Collection do
       end
     end
 
+    def valid?(%{spec: spec, opts: opts}, input, path) do
+      with :ok <- check_enumerable(input, path, opts),
+           :ok <- check_kind_of(input, path, opts),
+             :ok <- check_distinct(input, path, opts),
+             :ok <- check_counts(input, path, opts) do
+        input
+        |> Stream.with_index()
+        |> Stream.map(fn {elem, i} -> Conformable.valid?(spec, elem, path ++ [i]) end)
+        |> Enum.all?(& &1)
+      end
+    end
+
     defp convert(results, type) do
       Enum.into(results, type)
     end

--- a/lib/norm/core/schema.ex
+++ b/lib/norm/core/schema.ex
@@ -68,6 +68,27 @@ defmodule Norm.Core.Schema do
       end
     end
 
+    def valid?(%Schema{specs: specs}, %{__struct__: module} = input, path) when not is_nil(module) do
+      check_specs_validity(specs, Map.from_struct(input), path)
+    end
+
+    def valid?(%Schema{specs: specs}, input, path) do
+      check_specs_validity(specs, input, path)
+    end
+
+    defp check_specs_validity(specs, input, path) do
+      input
+      |> Stream.map(fn spec -> check_spec_validity(spec, specs, path) end)
+      |> Enum.all?(& &1)
+    end
+
+    defp check_spec_validity({key, value}, specs, path) do
+      case Map.get(specs, key) do
+        nil -> true
+        spec -> Conformable.valid?(spec, value, path ++ [key])
+      end
+    end
+
     defp check_specs(specs, input, path) do
       results =
         input

--- a/lib/norm/core/selection.ex
+++ b/lib/norm/core/selection.ex
@@ -93,6 +93,24 @@ defmodule Norm.Core.Selection do
       end
     end
 
+    def valid?(%{required: required, schema: schema}, input, path) do
+      Conformable.valid?(schema, input, path) && valid_keys?(required, input)
+    end
+
+    defp valid_keys?([] = _required, _input), do: true
+
+    defp valid_keys?([{key, _inner} | rest], input) do
+      if valid_key?(key, input), do: valid_keys?(rest, input), else: false
+    end
+
+    defp valid_keys?([key | rest], input) do
+      if valid_key?(key, input), do: valid_keys?(rest, input), else: false
+    end
+
+    defp valid_key?(key, input) when is_map(input), do: Map.has_key?(input, key)
+
+    defp valid_key?(_key, _input), do: true
+
     defp ensure_keys([], _conformed, _path, errors), do: errors
     defp ensure_keys([{key, inner} | rest], conformed, path, errors) do
       case ensure_key(key, conformed, path) do

--- a/lib/norm/core/spec.ex
+++ b/lib/norm/core/spec.ex
@@ -124,6 +124,11 @@ defmodule Norm.Core.Spec do
           raise ArgumentError, "Predicates must return a boolean value"
       end
     end
+
+    def valid?(%{f: _f, predicate: _pred} = spec, input, path) do
+      {status, _} = conform(spec, input, path)
+      status == :ok
+    end
   end
 
   @doc false

--- a/lib/norm/core/spec/and.ex
+++ b/lib/norm/core/spec/and.ex
@@ -27,6 +27,10 @@ defmodule Norm.Core.Spec.And do
         Conformable.conform(r, input, path)
       end
     end
+
+    def valid?(%{left: l, right: r}, input, path) do
+      Conformable.valid?(l, input, path) && Conformable.valid?(r, input, path)
+    end
   end
 
   if Code.ensure_loaded?(StreamData) do

--- a/lib/norm/core/spec/or.ex
+++ b/lib/norm/core/spec/or.ex
@@ -21,6 +21,10 @@ defmodule Norm.Core.Spec.Or do
           end
       end
     end
+
+    def valid?(%{left: l, right: r}, input, path) do
+      Conform.valid?(l, input, path) or Conform.valid?(r, input, path)
+    end
   end
 
   if Code.ensure_loaded?(StreamData) do

--- a/lib/norm/generator.ex
+++ b/lib/norm/generator.ex
@@ -14,6 +14,10 @@ defmodule Norm.Generator do
     def conform(%{conformer: c}, input, path) do
       Norm.Conformer.Conformable.conform(c, input, path)
     end
+
+    def valid?(%{conformer: c}, input, path) do
+      Norm.Conformer.Conformable.valid?(c, input, path)
+    end
   end
 
   defimpl Norm.Generatable do


### PR DESCRIPTION
**Problem**:
A conformity check is building two separate lists, consisting of the valid and invalid records, with a max total sum of the length of the input, which is becoming prohibitively slower after ~30 thousand records.
This holds true for a validation check, as under the hood it performs a conformity check and matches the result.

**Proposal**:
Optimise the validation check to not keep temporary results, while replicating the conformity check patterns. As an extra bonus (for multiple checks performed under a single validation) the validation stops once any check fails.

**Benchmarks**:
50 runs for each implementation consisting of ~90 000 checks per run.
Results are in microseconds.

**valid?** | **conform**
 --- | ---
2012468 | 52446747
1958767 | 49930423
1981143 | 50477395
2005227 | 50175413
1996278 | 50631595
2015621 | 53384663
1962915 | 51014405
2057126 | 50375344
1960135 | 50951396
1963531 | 50061197
1929721 | 50220423
1948214 | 49930450
1952217 | 49802433
1997368 | 49696173
1967032 | 50046508
1972836 | 49406972
1938450 | 49817945
1959891 | 49687747
1961860 | 49447045
1956255 | 49610711
1997596 | 49249689
1951382 | 49329118
2012229 | 49438534
1937561 | 49320431
1920401 | 49417229
1932584 | 50215488
1932026 | 50173875
1908881 | 50565533
1917214 | 50346232
1915676 | 50206065
1961261 | 49412046
1925107 | 49344110
1926179 | 49652765
1903635 | 49788570
1983483 | 49258780
1981491 | 49438113
1997598 | 57861646
1967174 | 57654857
2037674 | 58126992
1965466 | 57942112
1951443 | 58370191
1952561 | 58220536
1944028 | 58091247
1960469 | 58051644
1942835 | 49605340
1966198 | 49329768
1977263 | 49310646
1967109 | 49470729
1938717 | 49455685
1962793 | 49598098

implementation | min | max | mean
--- | --- | --- | ---
**valid?** | 1903635 | 2057126 | 1962701.78
**conform** | 49249689 | 58370191 | 51267221.08